### PR TITLE
:bug: fix app variable error and edit pipeline error

### DIFF
--- a/saagieapi/apps/apps.py
+++ b/saagieapi/apps/apps.py
@@ -47,7 +47,7 @@ class Apps:
             Dict of app information
         """
         params = {
-            "projectId": project_id,
+            "id": project_id,
             "instancesLimit": instances_limit,
             "versionsLimit": versions_limit,
             "versionsOnlyCurrent": versions_only_current,

--- a/saagieapi/pipelines/pipelines.py
+++ b/saagieapi/pipelines/pipelines.py
@@ -393,8 +393,8 @@ class Pipelines:
             previous_alerting = previous_pipeline_info["alerting"]
             if previous_alerting:
                 params["alerting"] = {
-                    "emails": previous_pipeline_info["emails"],
-                    "statusList": previous_pipeline_info["statusList"],
+                    "emails": previous_alerting["emails"],
+                    "statusList": previous_alerting["statusList"],
                 }
 
         result = self.saagie_api.client.execute(query=gql(GQL_EDIT_PIPELINE), variable_values=params)


### PR DESCRIPTION
In the class Apps, for the function list_for_project, we should use "id" in the params instead of "projectId"
In the class Pipelines, fix edit function